### PR TITLE
fix: version validation

### DIFF
--- a/src/turbo-helpers.ts
+++ b/src/turbo-helpers.ts
@@ -35,7 +35,11 @@ export const getTurboMajorVersion = async (
       )
       return false
     }
-    major = semver.major(turboMajorVersion)
+    major = semver.coerce(turboMajorVersion)?.major
+    if (!major) {
+      setFailed(`Couldn't parse turbo major version from package.json: ${turboMajorVersion}`)
+      return false
+    }
   } else {
     major = parseInt(turboMajorVersion)
   }

--- a/src/turbo-helpers.ts
+++ b/src/turbo-helpers.ts
@@ -36,7 +36,7 @@ export const getTurboMajorVersion = async (
       return false
     }
     major = semver.coerce(turboMajorVersion)?.major
-    if (!major) {
+    if (major === null) {
       setFailed(`Couldn't parse turbo major version from package.json: ${turboMajorVersion}`)
       return false
     }


### PR DESCRIPTION
Here's a revised explanation of the fix applied:

```ts
semver.major(turboMajorVersion)
```

When encountering a version string like `^2.3.4` in `package.json`, a `TypeError: Invalid Version` occurs because the caret (^) symbol isn't parsed correctly. To fix this issue, the following method was used:

```ts
semver.coerce(turboMajorVersion)?.major
```

This solution correctly extracts the major version without error.

![Screenshot](https://github.com/user-attachments/assets/28a40f45-465f-4ed5-af84-f06786859f4f)

Thank you.